### PR TITLE
Fix clippy precedence hint

### DIFF
--- a/src/cursor/sys/windows.rs
+++ b/src/cursor/sys/windows.rs
@@ -190,7 +190,9 @@ impl ScreenBufferCursor {
     fn save_position(&self) -> std::io::Result<()> {
         let position = self.position()?;
 
-        let bits = u64::from(u32::from(position.x as u16) << 16 | u32::from(position.y as u16));
+        let upper = u32::from(position.x as u16) << 16;
+        let lower = u32::from(position.y as u16);
+        let bits = u64::from(upper | lower);
         SAVED_CURSOR_POS.store(bits, Ordering::Relaxed);
 
         Ok(())


### PR DESCRIPTION
Stable clippy on windows understandibly warns about unclear precedence in this line.